### PR TITLE
[FIX] V2.2.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: "[BUG] Bug Report"
 description: Something is broken or behaving unexpectedly
 title: "[BUG] "
-labels: ["bug", "triage"]
+labels: ["type::bug"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,7 +1,7 @@
 name: "[ENHANCEMENT] Enhancement"
 description: Improve an existing feature without adding something entirely new
 title: "[ENHANCEMENT] "
-labels: ["enhancement", "triage"]
+labels: ["type::enhancement"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: "[FEATURE] Feature Request"
 description: Propose a new feature for Deck Shelves
 title: "[FEATURE] "
-labels: ["feature", "triage"]
+labels: ["type::feature"]
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -41,14 +41,13 @@ jobs:
             const { owner, repo } = context.repo;
 
             const required = [
-              // OS labels
-              { name: "OS::SteamOS",      color: "1d76db", description: "Reported on SteamOS (stable)" },
-              { name: "OS::SteamOSBeta",  color: "0075ca", description: "Reported on SteamOS beta/preview" },
-              { name: "OS::Bazzite",      color: "e4e669", description: "Reported on Bazzite" },
-              { name: "OS::Chimera",      color: "d93f0b", description: "Reported on ChimeraOS" },
-              { name: "OS::MacOS",        color: "555555", description: "Reported on macOS" },
-              { name: "OS::Windows",      color: "0052cc", description: "Reported on Windows" },
-              { name: "OS::OtherHoloISO", color: "bfd4f2", description: "Reported on HoloISO or similar" },
+              // OS labels (SteamOS beta is expressed as OS::SteamOS + release::beta)
+              { name: "OS::SteamOS",      color: "1F8FFF", description: "Reported on SteamOS (official)" },
+              { name: "OS::Bazzite",      color: "9333EA", description: "Reported on Bazzite" },
+              { name: "OS::Chimera",      color: "F97316", description: "Reported on ChimeraOS" },
+              { name: "OS::MacOS",        color: "A1A1AA", description: "Reported on macOS" },
+              { name: "OS::Windows",      color: "0078D6", description: "Reported on Windows" },
+              { name: "OS::OtherHoloISO", color: "10B981", description: "Reported on a HoloISO-derived distro other than the listed ones" },
               // Mode labels (Deck Shelves supports Game Mode and Big Picture only)
               { name: "mode::GameMode",    color: "0e8a16", description: "Affects Game Mode / GamepadUI" },
               { name: "mode::BigPicture",  color: "006b75", description: "Affects Big Picture mode" },
@@ -57,11 +56,31 @@ jobs:
               { name: "release::beta",    color: "e4e669", description: "Present in a beta/pre-release" },
               // Type labels
               { name: "type::bug",         color: "d73a4a", description: "Something isn't working" },
-              { name: "type::feature",     color: "a2eeef", description: "New feature request" },
-              { name: "type::enhancement", color: "84b6eb", description: "Enhancement to existing feature" },
+              { name: "type::feature",     color: "0E8A16", description: "New feature or request" },
+              { name: "type::enhancement", color: "a2eeef", description: "Improvement to an existing feature" },
+              // Priority labels (assigned automatically by issue-priority-labeler; critical is manual-only)
+              { name: "priority::critical", color: "B60205", description: "Critical — immediate fix (crash, regression, security)" },
+              { name: "priority::high",     color: "D93F0B", description: "High — prioritized fix in the next PATCH release" },
+              { name: "priority::medium",   color: "FBCA04", description: "Medium — fix planned within a sprint" },
+              { name: "priority::low",      color: "0E8A16", description: "Low — backlog, addressed when capacity allows" },
+              // Area labels (assigned automatically by pr-auto-labeler)
+              { name: "area::core",         color: "5319E7", description: "src/core/ — sensitive logic" },
+              { name: "area::runtime",      color: "5319E7", description: "src/runtime/ — Steam integration" },
+              { name: "area::ui",           color: "1D76DB", description: "src/components/ — React UI" },
+              { name: "area::integrations", color: "5319E7", description: "src/integrations/ — external APIs" },
+              { name: "area::store",        color: "1D76DB", description: "src/store/ — global state" },
+              { name: "area::domain",       color: "0E8A16", description: "src/domain/ — pure business rules" },
+              { name: "area::steam",        color: "5319E7", description: "src/steam/ — Steam resolver" },
+              { name: "area::i18n",         color: "FFD700", description: "i18n/ — locale files" },
+              { name: "area::tests",        color: "C5DEF5", description: "src/test/ — test suite" },
+              { name: "area::ci",           color: "000000", description: ".github/ — workflows / CI" },
+              { name: "area::docs",         color: "0075CA", description: "docs/ — documentation" },
+              { name: "area::backend",      color: "FFA500", description: "main.py — Python backend" },
             ];
 
-            const deprecated = ["mode desktop"];
+            // SteamOSBeta is replaced by the OS::SteamOS + release::beta pair.
+            // The `documentation` default GitHub label is replaced by area::docs.
+            const deprecated = ["mode desktop", "OS::SteamOSBeta", "documentation"];
 
             const existing = await github.paginate(github.rest.issues.listLabelsForRepo, { owner, repo, per_page: 100 });
             const existingMap = new Map(existing.map(l => [l.name, l]));

--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -58,6 +58,9 @@ jobs:
               { name: "type::bug",         color: "d73a4a", description: "Something isn't working" },
               { name: "type::feature",     color: "0E8A16", description: "New feature or request" },
               { name: "type::enhancement", color: "a2eeef", description: "Improvement to an existing feature" },
+              { name: "type::duplicated",  color: "cfd3d7", description: "Issue or pull request already exists" },
+              { name: "type::invalid",     color: "e4e669", description: "Not a real issue or doesn't seem right" },
+              { name: "type::wontfix",     color: "ffffff", description: "This will not be worked on" },
               // Priority labels (assigned automatically by issue-priority-labeler; critical is manual-only)
               { name: "priority::critical", color: "B60205", description: "Critical — immediate fix (crash, regression, security)" },
               { name: "priority::high",     color: "D93F0B", description: "High — prioritized fix in the next PATCH release" },
@@ -78,9 +81,8 @@ jobs:
               { name: "area::backend",      color: "FFA500", description: "main.py — Python backend" },
             ];
 
-            // SteamOSBeta is replaced by the OS::SteamOS + release::beta pair.
             // The `documentation` default GitHub label is replaced by area::docs.
-            const deprecated = ["mode desktop", "OS::SteamOSBeta", "documentation"];
+            const deprecated = ["mode desktop", "documentation"];
 
             const existing = await github.paginate(github.rest.issues.listLabelsForRepo, { owner, repo, per_page: 100 });
             const existingMap = new Map(existing.map(l => [l.name, l]));

--- a/.github/workflows/issue-auto-labeler.yml
+++ b/.github/workflows/issue-auto-labeler.yml
@@ -1,0 +1,39 @@
+name: Auto-label issues by title
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply type label from issue title
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            if (!issue) return;
+            const title = (issue.title ?? "").toLowerCase();
+
+            const titleType =
+              /^\s*\[?\s*(fix|bug|hotfix)\b/.test(title)            ? "type::bug" :
+              /^\s*\[?\s*(feat|feature)\b/.test(title)            ? "type::feature" :
+              /^\s*\[?\s*(enh|enhance|enhancement|improve)\b/.test(title) ? "type::enhancement" :
+              null;
+
+            if (!titleType) return;
+
+            const current = (issue.labels ?? []).map(l => l.name || "");
+            if (current.includes(titleType)) return;
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              labels: [titleType],
+            });

--- a/.github/workflows/issue-os-labeler.yml
+++ b/.github/workflows/issue-os-labeler.yml
@@ -24,18 +24,17 @@ jobs:
             const text  = `${title}\n${body}`;
 
             // Detection order matters: more specific labels must be checked
-            // first so they win over broader fallbacks. SteamOSBeta is the
-            // narrowest — only fires when "steamos" appears alongside any
-            // beta / preview signal — and is intentionally checked BEFORE
-            // the generic SteamOS bucket below.
+            // first so they win over broader fallbacks. The SteamOS-beta
+            // signal is detected here as a flag — when it fires we apply
+            // OS::SteamOS + release::beta instead of a dedicated beta label
+            // (kept consistent with the plugin release-channel convention).
+            const steamOsBetaPatterns = [
+              /\bsteam\s*os\b[\s\S]{0,80}\b(beta|preview|3\.[7-9]\d*\.\d+)\b/i,
+              /\b(beta|preview)\b[\s\S]{0,80}\bsteam\s*os\b/i,
+            ];
+            const isSteamOsBeta = steamOsBetaPatterns.some((p) => p.test(text));
+
             const buckets = [
-              {
-                label: "OS::SteamOSBeta",
-                patterns: [
-                  /\bsteam\s*os\b[\s\S]{0,80}\b(beta|preview|3\.[7-9]\d*\.\d+)\b/i,
-                  /\b(beta|preview)\b[\s\S]{0,80}\bsteam\s*os\b/i,
-                ],
-              },
               { label: "OS::Bazzite",       patterns: [/\bbazzite\b/i] },
               { label: "OS::Chimera",       patterns: [/\bchimera\s*os\b/i, /\bchimeraos\b/i, /\bchimera\b/i] },
               { label: "OS::MacOS",         patterns: [/\bmac\s*os\b/i, /\bmacos\b/i, /\bdarwin\b/i, /\bosx\b/i] },
@@ -66,9 +65,13 @@ jobs:
               }
             }
 
-            // If SteamOSBeta matched, also keep SteamOS — they're not mutually
-            // exclusive (the issue still references SteamOS, just a beta build).
-            if (toAdd.has("OS::SteamOSBeta")) toAdd.add("OS::SteamOS");
+            // SteamOS-beta signal: apply OS::SteamOS + release::beta together
+            // (no dedicated OS::SteamOSBeta label — kept in line with the
+            // plugin release-channel convention).
+            if (isSteamOsBeta) {
+              toAdd.add("OS::SteamOS");
+              toAdd.add("release::beta");
+            }
 
             // Fallback: if no specific OS matched but the issue clearly
             // references a Deck/HoloISO-style environment (e.g. "Decky",

--- a/.github/workflows/issue-priority-labeler.yml
+++ b/.github/workflows/issue-priority-labeler.yml
@@ -26,11 +26,11 @@ jobs:
             if (hasAnyMatching(/^priority::/)) return;
 
             let priority = null;
-            if (has("type::bug") && (has("os::steamos") || has("os::steamosbeta"))) {
+            if (has("type::bug") && has("os::steamos")) {
               priority = "priority::high";
             } else if (has("type::bug")) {
               priority = "priority::medium";
-            } else if (has("type::enhancement", "type::feature", "documentation", "area::docs")) {
+            } else if (has("type::enhancement", "type::feature", "area::docs")) {
               priority = "priority::low";
             }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **"Use shelf as Recents (experimental)" crash on library open after Steam restart (#60).** Root cause: `filterKnownAppIds` validated only `appStore.GetAppOverviewByAppID` + `app_type`, but the recents component crashes in Steam's `userCollections` getter (`Cannot read properties of undefined (reading 'values')`) for appids that aren't present in `collectionStore.allAppsCollection.apps` — typical for non-owned games (wishlist / store metadata / friends-playing entries that appStore happens to know about). New `getOwnedAppIdSet()` reads the owned-set from `collectionStore.allAppsCollection.apps` (falling back to `allGamesCollection` / `localGamesCollection`) and returns `null` when the store hasn't populated yet. `filterKnownAppIds` now requires every id to be in that owned set AND have a renderable `app_type` AND have an appStore overview — the only filter that maps 1:1 to "this id won't crash the recents renderer." When `getOwnedAppIdSet()` returns `null` (collectionStore not ready, typical 0–80 s window on cold boot), `scheduleResolve` bails silently instead of injecting; once the store comes online the periodic + event-driven retries pick the strict path up.
+- **"Use shelf as Recents" no longer needs a Steam restart to take effect when the first shelf is an online source.** Removed the PR #58 unfiltered fallback (`cachedAppIds = valid` when strict rejected all) which was the source of the crash above — promoting unfiltered ids was inherently unsafe regardless of timing. Replaced with deterministic next-candidate promotion: when the strict filter returns 0 against a ready `collectionStore`, the resolver moves to the next visible shelf instead of trying to inject. Wishlist / store shelves in position 0 are now skipped cleanly (the user's first owned shelf takes their slot). Resolve failures in the `.catch` path also promote to the next candidate now, instead of leaving recents empty.
+- **Faster post-boot recovery for the recents replace.** Added a `collectionStore.on("change")` listener so the resolver re-runs immediately when `allAppsCollection` finishes populating, instead of waiting up to 90 s for the next periodic tick. Bootstrap retry timers extended from `[300, 1000, 2500, 5000, 10000]` ms to `[300, 1000, 2500, 5000, 10000, 20000, 40000, 80000]` ms so the cold-boot window is fully covered before the periodic interval takes over.
+
 ## [2.2.1] - 2026-05-14
 
 ### Added

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,11 @@ changelog, see [CHANGELOG.md](CHANGELOG.md).
 
 ## [Unreleased]
 
+### Fixed
+
+- **"Use shelf as Recents (experimental)" no longer crashes the library after a Steam restart (#60).** With the toggle on, opening Library on a fresh boot could show Steam's error page (`An error occurred while rendering this content`). The injection now waits for Steam's library catalog to be ready before it touches the recents shelf, and only ever sends games you actually own — wishlist / store entries you don't own are skipped automatically. If your first shelf is a wishlist or store shelf, recents falls through to the next visible shelf instead of trying to use a non-owned game (which is what caused the crash).
+- **"Use shelf as Recents" applies without needing to restart Steam.** Toggling the option on now updates the recents shelf as soon as Steam has finished loading your library — usually within a few seconds — instead of requiring a restart for the swap to take effect.
+
 ## [2.2.1] - 2026-05-14
 
 ### Added

--- a/src/runtime/recentsReplace.tsx
+++ b/src/runtime/recentsReplace.tsx
@@ -105,11 +105,54 @@ function markReplaceFailed(reason: string) {
  *  `userCollections` getter because those collections don't index them. */
 const RENDERABLE_STEAM_APP_TYPES: ReadonlySet<number> = new Set([1, 2, 1073741824]); // Game, Application, Non-Steam Shortcut
 
+/** The crash in issue #60 ("Cannot read properties of undefined (reading
+ *  'values')") originates from Steam's `userCollections` getter — which
+ *  lives in `collectionStore`, NOT `appStore`. An appid can have a valid
+ *  appStore overview yet not be present in any user collection (typical
+ *  for wishlist / store-recommendation ids the user doesn't own), and
+ *  those are the ones that crash the recents renderer. Membership in
+ *  `allAppsCollection.apps` (a Set of owned/installed appids) is the only
+ *  reliable signal that an id is safe to inject. */
+function getOwnedAppIdSet(): Set<number> | null {
+  const cs: any = (globalThis as any).collectionStore;
+  if (!cs) return null;
+  const coll = cs.allAppsCollection ?? cs.allGamesCollection ?? cs.localGamesCollection;
+  const apps = coll?.apps;
+  if (!apps) return null;
+  const out = new Set<number>();
+  try {
+    if (apps instanceof Set) {
+      for (const v of apps) {
+        const id = typeof v === "number" ? v : Number((v as any)?.appid ?? (v as any)?.nAppID);
+        if (Number.isFinite(id) && id > 0) out.add(id);
+      }
+    } else if (typeof apps?.values === "function") {
+      for (const v of apps.values()) {
+        const id = typeof v === "number" ? v : Number((v as any)?.appid ?? (v as any)?.nAppID);
+        if (Number.isFinite(id) && id > 0) out.add(id);
+      }
+    } else if (Array.isArray(apps)) {
+      for (const v of apps) {
+        const id = typeof v === "number" ? v : Number((v as any)?.appid ?? (v as any)?.nAppID);
+        if (Number.isFinite(id) && id > 0) out.add(id);
+      }
+    }
+  } catch { return null; }
+  return out.size > 0 ? out : null;
+}
+
 function filterKnownAppIds(ids: number[]): number[] {
   const store: any = (globalThis as any).appStore;
   if (!store || typeof store.GetAppOverviewByAppID !== "function") return [];
+  // Owned-set check is the real safety net against issue #60: only ids
+  // that collectionStore knows about can be safely rendered. Null means
+  // collectionStore isn't ready yet — bail out (return []) so the caller
+  // waits for the retry tick rather than injecting prematurely.
+  const owned = getOwnedAppIdSet();
+  if (!owned) return [];
   const out: number[] = [];
   for (const id of ids) {
+    if (!owned.has(id)) continue;
     try {
       const ov = store.GetAppOverviewByAppID(id);
       if (ov && typeof ov.app_type === "number" && RENDERABLE_STEAM_APP_TYPES.has(ov.app_type)) {
@@ -189,18 +232,25 @@ function scheduleResolve(shelf: any) {
       const prev = cachedAppIds;
       const valid = Array.isArray(ids) ? ids.filter((n) => typeof n === "number" && n > 0) : [];
       const known = filterKnownAppIds(valid);
-      if (known.length === 0 && valid.length > 0) {
-        cachedAppIds = valid;
-        cachedShelfId = shelf.id;
-        cachedTitle = shelf.title ?? cachedTitle;
-        const changed = prev?.length !== cachedAppIds.length || prev?.some((v, i) => v !== cachedAppIds![i]);
-        if (changed) { notifyInjectingChange(); forceRemountRecents(); }
-        return;
-      }
       if (known.length === 0) {
-        // Shelf resolved to 0 native-renderable apps — try the next
-        // candidate (normals first, then visible smart shelves). setTimeout
-        // so resolvePromise is null before the next call.
+        if (valid.length > 0 && !getOwnedAppIdSet()) {
+          // Fresh-boot window: collectionStore hasn't built
+          // allAppsCollection yet. Injecting ids before that's ready
+          // crashes Steam's userCollections getter (issue #60). Don't
+          // promote to next candidate either — every shelf will look
+          // "empty" until the store loads. Bail silently; the periodic
+          // tick + RegisterForAppOverviewChanges will retry once
+          // collectionStore comes online.
+          lastResolveKey = "";
+          return;
+        }
+        // Strict filter rejected every id. This is either an online shelf
+        // (wishlist/store) returning non-owned games, or a shelf whose
+        // contents are all unrenderable types (Tool, DLC, etc.). Promote
+        // to the next candidate — never fall back to unfiltered ids, even
+        // partially, because Steam's recents component cannot safely
+        // render anything outside the strict whitelist (Game / Application
+        // / Non-Steam Shortcut).
         const candidates = visibleCandidateShelves();
         const currentIdx = candidates.findIndex((sh: any) => sh.id === shelf.id);
         const next = candidates[currentIdx + 1];
@@ -223,7 +273,18 @@ function scheduleResolve(shelf: any) {
     })
     .catch((err) => {
       logWarn("RUNTIME", "resolveShelfAppIds failed", String(err));
-      cachedAppIds = [];
+      // Resolve failure (typical for online shelves when the network is
+      // down or the user has online features off) — promote to the next
+      // candidate so a failed first shelf doesn't leave recents empty.
+      const candidates = visibleCandidateShelves();
+      const currentIdx = candidates.findIndex((sh: any) => sh.id === shelf.id);
+      const next = candidates[currentIdx + 1];
+      if (next) {
+        lastResolveKey = "";
+        setTimeout(() => scheduleResolve(next), 0);
+      } else {
+        cachedAppIds = [];
+      }
     })
     .finally(() => { resolvePromise = null; });
 }
@@ -421,7 +482,9 @@ export function installRecentsReplace(routerHook: any): PatchHandle {
   // If already on home at install time, we trigger resolve ourselves.
   // Timers only call scheduleResolve — forceRemountRecents is called by
   // scheduleResolve internally when data changes, so we never disturb
-  // the native tree unnecessarily.
+  // the native tree unnecessarily. Range covers the first ~80s because
+  // collectionStore.allAppsCollection can take that long to populate on
+  // a cold boot (issue #60); after that the 90s periodic tick takes over.
   const bootstrapTimers: ReturnType<typeof setTimeout>[] = [];
   const tryResolve = () => {
     if (replaceFailed || (cachedAppIds && cachedAppIds.length > 0)) return;
@@ -430,9 +493,28 @@ export function installRecentsReplace(routerHook: any): PatchHandle {
     lastResolveKey = "";
     scheduleResolve(shelf);
   };
-  for (const d of [300, 1000, 2500, 5000, 10000]) {
+  for (const d of [300, 1000, 2500, 5000, 10000, 20000, 40000, 80000]) {
     bootstrapTimers.push(setTimeout(tryResolve, d));
   }
+
+  // collectionStore.on('change') fires when the user's collections (and
+  // the underlying allAppsCollection.apps set) finish populating on cold
+  // boot, or when the user installs/removes an app. Either trigger is a
+  // good moment to re-resolve: the boot case unblocks the filter that
+  // requires owned-set membership, and the install/uninstall case keeps
+  // the recents list aligned with the user's library state.
+  let unsubColl: (() => void) | null = null;
+  try {
+    const cs: any = (globalThis as any).collectionStore;
+    if (cs && typeof cs.on === "function") {
+      const handler = () => {
+        const shelf = activeFirstShelf();
+        if (shelf) { lastResolveKey = ""; scheduleResolve(shelf); }
+      };
+      cs.on("change", handler);
+      unsubColl = () => { try { cs.off?.("change", handler); } catch {} };
+    }
+  } catch {}
 
   let resumeUnsub: (() => void) | null = null;
   try {
@@ -454,6 +536,7 @@ export function installRecentsReplace(routerHook: any): PatchHandle {
       try { routerHook.removePatch?.("/library/home", patch); } catch {}
       try { unsubSettings?.(); } catch {}
       try { unsubApp?.(); } catch {}
+      try { unsubColl?.(); } catch {}
       try { uninstallErrorTrap(); } catch {}
       try { resumeUnsub?.(); } catch {}
       clearInterval(periodicTimer);


### PR DESCRIPTION
<!--
  PR title MUST start with one of these tags:
    [FIX]         — Bug fix
    [ENHANCEMENT] — Small improvement
    [PERF]        — Performance improvement
    [QA]          — QA harness / test instrumentation
    [REFACTOR]    — Refactor/restructure
    [CLEANUP]     — Code cleanup
    [FEATURE]     — New feature

  Example: [FIX] Prevent shelf from disappearing on reboot
-->

## Description

<!-- AUTOFILL:DESCRIPTION:START -->
<!-- Describe what this PR does and why. -->
<!-- AUTOFILL:DESCRIPTION:END -->

## Related Issues

Closes #60 

## Changelog

<!-- AUTOFILL:CHANGELOG:START -->
### Fixed

- **"Use shelf as Recents (experimental)" crash on library open after Steam restart (#60).** Root cause: `filterKnownAppIds` validated only `appStore.GetAppOverviewByAppID` + `app_type`, but the recents component crashes in Steam's `userCollections` getter (`Cannot read properties of undefined (reading 'values')`) for appids that aren't present in `collectionStore.allAppsCollection.apps` — typical for non-owned games (wishlist / store metadata / friends-playing entries that appStore happens to know about). New `getOwnedAppIdSet()` reads the owned-set from `collectionStore.allAppsCollection.apps` (falling back to `allGamesCollection` / `localGamesCollection`) and returns `null` when the store hasn't populated yet. `filterKnownAppIds` now requires every id to be in that owned set AND have a renderable `app_type` AND have an appStore overview — the only filter that maps 1:1 to "this id won't crash the recents renderer." When `getOwnedAppIdSet()` returns `null` (collectionStore not ready, typical 0–80 s window on cold boot), `scheduleResolve` bails silently instead of injecting; once the store comes online the periodic + event-driven retries pick the strict path up.
- **"Use shelf as Recents" no longer needs a Steam restart to take effect when the first shelf is an online source.** Removed the PR #58 unfiltered fallback (`cachedAppIds = valid` when strict rejected all) which was the source of the crash above — promoting unfiltered ids was inherently unsafe regardless of timing. Replaced with deterministic next-candidate promotion: when the strict filter returns 0 against a ready `collectionStore`, the resolver moves to the next visible shelf instead of trying to inject. Wishlist / store shelves in position 0 are now skipped cleanly (the user's first owned shelf takes their slot). Resolve failures in the `.catch` path also promote to the next candidate now, instead of leaving recents empty.
- **Faster post-boot recovery for the recents replace.** Added a `collectionStore.on("change")` listener so the resolver re-runs immediately when `allAppsCollection` finishes populating, instead of waiting up to 90 s for the next periodic tick. Bootstrap retry timers extended from `[300, 1000, 2500, 5000, 10000]` ms to `[300, 1000, 2500, 5000, 10000, 20000, 40000, 80000]` ms so the cold-boot window is fully covered before the periodic interval takes over.
<!-- AUTOFILL:CHANGELOG:END -->

## Release Notes

<!-- AUTOFILL:RELEASE_NOTES:START -->
### Fixed

- **"Use shelf as Recents (experimental)" no longer crashes the library after a Steam restart (#60).** With the toggle on, opening Library on a fresh boot could show Steam's error page (`An error occurred while rendering this content`). The injection now waits for Steam's library catalog to be ready before it touches the recents shelf, and only ever sends games you actually own — wishlist / store entries you don't own are skipped automatically. If your first shelf is a wishlist or store shelf, recents falls through to the next visible shelf instead of trying to use a non-owned game (which is what caused the crash).
- **"Use shelf as Recents" applies without needing to restart Steam.** Toggling the option on now updates the recents shelf as soon as Steam has finished loading your library — usually within a few seconds — instead of requiring a restart for the swap to take effect.
<!-- AUTOFILL:RELEASE_NOTES:END -->

## Type of Change

<!-- At least ONE of the first three rows MUST be checked. The CI validator
     enforces this — a PR with none of the main categories selected fails the
     `pr-checklist` check. -->

- [ ] Refactor / restructure (`[REFACTOR]`)
- [ ] New feature / Code cleanup (`[FEATURE]`, `[CLEANUP]`)
- [x] Bug fix / Enhancement / QA / Performance update (`[FIX]`, `[ENHANCEMENT]`, `[QA]`, `[PERF]`)
- [ ] Documentation update
- [ ] i18n / localization
- [ ] Build / CI change

## Checklist

<!-- ALL items must be checked. The "i18n keys" line is required only when the
     "i18n / localization" Type of Change is checked above; otherwise it can be
     left unchecked and the validator will skip it. -->

- [x] My PR title starts with `[FIX]`, `[ENHANCEMENT]`, `[PERF]`, `[QA]`, `[REFACTOR]`, `[CLEANUP]`, or `[FEATURE]`.
- [x] I added my changes to `CHANGELOG.md` and `RELEASE_NOTES.md` under `## [Unreleased]`.
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] My code follows the project's code style (2 spaces, semicolons, double quotes).
- [x] I ran `pnpm run build:plugin` with no errors.
- [x] I ran `bash scripts/build/validate-compat.sh` and all checks pass.
- [x] I tested on a Steam Deck (or explained why this isn't needed).
- [x] If I added i18n keys, I added them to **all** locale files.

## Screenshots / Videos

<!-- If applicable, add screenshots or videos showing the change on Steam Deck. -->

## Additional Notes

<!-- Anything else reviewers should know. -->
